### PR TITLE
Changed base image for dockers to support Gazebo rendering

### DIFF
--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM nvidia/opengl:1.2-glvnd-runtime-ubuntu18.04
 
 # Use ARG - persists only during docker build
 # https://github.com/moby/moby/issues/4032#issuecomment-192327844

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
 
 # Use ARG - persists only during docker build
 # https://github.com/moby/moby/issues/4032#issuecomment-192327844


### PR DESCRIPTION
**Changed base image to enable running of Gazebo in docker container.** 

It would probably make sense to have different base images depending on necessity for OpenGL, however, this 
are Dockerfiles for simulation, therefore, they should contain gazebo. 

There could be some use-cases where we could hypothetically run ROS part on one PC and Gazebo on another PC, however, such use-cases would require advanced network configuration therefore, changing one line in docker, shouldn't be problem. 

I've put `runtime` image as explained [here](https://stackoverflow.com/questions/56405159/what-is-the-difference-between-devel-and-runtime-tag-for-a-docker-container). If someone needs to build packages that relate to CUDA, and compilation chain (sometimes DL architectures), it's advisable to use `devel` as base image. 